### PR TITLE
Merge overlapping alerts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 zstandard = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"

--- a/ealert/summarize.py
+++ b/ealert/summarize.py
@@ -42,6 +42,13 @@ def merge_stats(s1, s2):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('jsondir')
+    parser.add_argument(
+        '--min-gap',
+        action='store',
+        type=int,
+        default=600,
+        help='number of seconds before we treat a message with the same subject as belonging to a new alert',
+    )
     parser.add_argument('-r', '--raw', action='store_true')
     args = parser.parse_args()
 
@@ -149,7 +156,7 @@ def main():
                     merge = True
 
                 for ts_pair in itertools.product([start1, end1], [start2, end2]):
-                    if abs(ts_pair[0] - ts_pair[1]).total_seconds() < 90:
+                    if abs(ts_pair[0] - ts_pair[1]).total_seconds() < args.min_gap:
                         # close enough
                         merge = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ealert
-version = 1.1.0
+version = 1.2.0
 description = Emergency Alert statistics
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
The body checksum is no longer reliably the same across an entire alert, so we have to try to guess which messages belong together. This heuristic worked for the sample data from 2023-07-27 where alerts with the same subject were triggered at 15:02 and 15:10, so I feel pretty good about it.